### PR TITLE
Add yesterday history section

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import DataService from './services/dataService';
 
-test('renders learn react link', () => {
+test('renders app header', () => {
+  DataService.configure({ dataSource: 'localStorage', syncToFirestore: false });
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText('💪 Muscle Tracker');
+  expect(headerElement).toBeInTheDocument();
 });

--- a/src/pages/HistoryPage.css
+++ b/src/pages/HistoryPage.css
@@ -147,6 +147,17 @@
   font-weight: 600;
 }
 
+.yesterday-section {
+  margin-top: 1.5rem;
+}
+
+.yesterday-title {
+  color: #1f2937;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
 .no-sessions {
   text-align: center;
   padding: 3rem 2rem;
@@ -285,8 +296,12 @@
   .stat-label {
     font-size: 0.7rem;
   }
-  
+
   .selected-date-title {
+    font-size: 1rem;
+  }
+
+  .yesterday-title {
     font-size: 1rem;
   }
   

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -3,7 +3,7 @@ import { WorkoutSession } from '../types/workout';
 import DataService from '../services/dataService';
 import Calendar from '../components/history/Calendar';
 import WorkoutSessionCard from '../components/history/WorkoutSessionCard';
-import { getTodayString, formatDate, sortByDate } from '../utils/helpers';
+import { getTodayString, formatDate, sortByDate, getDaysAgo } from '../utils/helpers';
 import './HistoryPage.css';
 
 type ViewMode = 'calendar' | 'list';
@@ -13,6 +13,7 @@ const HistoryPage: React.FC = () => {
   const [viewMode, setViewMode] = useState<ViewMode>('calendar');
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<string>(getTodayString());
+  const [yesterdaySessions, setYesterdaySessions] = useState<WorkoutSession[]>([]);
   const [expandedSessions, setExpandedSessions] = useState<Set<string>>(new Set());
   const [isLoading, setIsLoading] = useState(true);
 
@@ -25,6 +26,8 @@ const HistoryPage: React.FC = () => {
     try {
       const allSessions = await DataService.getAllWorkoutSessions();
       setSessions(sortByDate(allSessions, true));
+      const yesterday = getDaysAgo(1);
+      setYesterdaySessions(allSessions.filter(session => session.date === yesterday));
     } catch (error) {
       console.error('セッションの読み込みに失敗しました:', error);
     } finally {
@@ -180,6 +183,25 @@ const HistoryPage: React.FC = () => {
               </div>
             </div>
           </div>
+
+          {yesterdaySessions.length > 0 && (
+            <div className="yesterday-section">
+              <h3 className="yesterday-title">
+                昨日({formatDate(getDaysAgo(1))})のワークアウト
+              </h3>
+              <div className="sessions-list">
+                {yesterdaySessions.map(session => (
+                  <WorkoutSessionCard
+                    key={session.id}
+                    session={session}
+                    isExpanded={expandedSessions.has(session.id)}
+                    onToggleExpand={handleToggleExpand}
+                    onDelete={handleDeleteSession}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
 
           {viewMode === 'calendar' && (
             <>


### PR DESCRIPTION
## Summary
- display yesterday's workout sessions on HistoryPage
- style new yesterday section
- improve default test to check the app header and avoid network calls

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68529cdf050c8320be4ca249aba70ad8